### PR TITLE
Improve getPoints() + explode() performance for large geometries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ foreach ($result as $item) {
 ```
 
 
+Testing
+-------
+```
+cd tests/
+GEOPHP_RUN_TESTS=1 php tests/test.php
+```
+
 Credit
 -------------------------------------------------
 

--- a/lib/geometry/Collection.class.php
+++ b/lib/geometry/Collection.class.php
@@ -231,7 +231,9 @@ abstract class Collection extends Geometry
   public function getPoints() {
     $points = array();
     foreach ($this->components as $component) {
-      $points = array_merge($points, $component->getPoints());
+      foreach ($component->getPoints() as $point) {
+        $points[] = $point;
+      }
     }
     return $points;
   }
@@ -290,7 +292,9 @@ abstract class Collection extends Geometry
   public function explode() {
     $parts = array();
     foreach ($this->components as $component) {
-      $parts = array_merge($parts, $component->explode());
+      foreach ($component->explode() as $subComponent) {
+        $parts[] = $subComponent;
+      }
     }
     return $parts;
   }


### PR DESCRIPTION
**Issue**
For geometries with 10k+ points, it can take 10+ seconds on a modern machine to call `getPoints()` or `pointInPolygon()`.

**Root Cause**
The points array was built using `array_merge()`, which gets more complex (n^2) as the array gets larger.

**Fix**
Use simple array appending instead of `array_merge()`

Before:

```
$ time ../vendor/bin/phpunit tests/largeInputTest.php 
real    0m13.354s
user    0m13.318s
sys 0m0.030s
```

After:

```
$ time ../vendor/bin/phpunit tests/largeInputTest.php 
real    0m0.194s
user    0m0.172s
sys 0m0.016s
```
